### PR TITLE
Added depth buffer support to d3d9graphics.

### DIFF
--- a/mod/brl.mod/dxgraphics.mod/d3d9graphics.bmx
+++ b/mod/brl.mod/dxgraphics.mod/d3d9graphics.bmx
@@ -34,7 +34,7 @@ End Type
 Function D3D9WndProc( hwnd,msg,wp,lp ) "win32"
 
 	bbSystemEmitOSEvent hwnd,msg,wp,lp,Null
-	
+
 	Select msg
 	Case WM_CLOSE
 		Return
@@ -56,7 +56,7 @@ Function OpenD3DDevice( hwnd,width,height,depth,hertz,flags )
 	EndIf
 
 	Local windowed=(depth=0)
-	Local fullscreen=(depth<>0)	
+	Local fullscreen=(depth<>0)
 
 	Local pp:D3DPRESENT_PARAMETERS=New D3DPRESENT_PARAMETERS
 	pp.BackBufferWidth=width
@@ -70,9 +70,50 @@ Function OpenD3DDevice( hwnd,width,height,depth,hertz,flags )
 	pp.Flags=D3DPRESENTFLAG_LOCKABLE_BACKBUFFER
 	pp.FullScreen_RefreshRateInHz=(hertz * fullscreen)
 	pp.PresentationInterval=D3DPRESENT_INTERVAL_ONE	'IMMEDIATE
+
+	Function CheckDepthFormat(format)
+	    Return _d3d.CheckDeviceFormat(0,D3DDEVTYPE_HAL,D3DFMT_X8R8G8B8,D3DUSAGE_DEPTHSTENCIL,D3DRTYPE_SURFACE,format)=D3D_OK
+	End Function
+
+	If flags&GRAPHICS_DEPTHBUFFER Or flags&GRAPHICS_STENCILBUFFER
+	    pp.EnableAutoDepthStencil = True
+	    If flags&GRAPHICS_STENCILBUFFER
+	        If Not CheckDepthFormat( D3DFMT_D24S8 )
+	            If Not CheckDepthFormat( D3DFMT_D24FS8 )
+	                If Not CheckDepthFormat( D3DFMT_D24X4S4 )
+	                    If Not CheckDepthFormat( D3DFMT_D15S1 )
+	                        Return False
+	                    Else
+	                        pp.AutoDepthStencilFormat = D3DFMT_D15S1
+	                    EndIf
+	                Else
+	                    pp.AutoDepthStencilFormat = D3DFMT_D24X4S4
+	                EndIf
+	            Else
+	                pp.AutoDepthStencilFormat = D3DFMT_D24FS8
+	            EndIf
+	        Else
+	            pp.AutoDepthStencilFormat = D3DFMT_D24S8
+	        EndIf
+	    Else
+	        If Not CheckDepthFormat( D3DFMT_D32 )
+	            If Not CheckDepthFormat( D3DFMT_D24X8 )
+	                If Not CheckDepthFormat( D3DFMT_D16 )
+	                    Return False
+	                Else
+	                    pp.AutoDepthStencilFormat = D3DFMT_D16
+	                EndIf
+	            Else
+	                pp.AutoDepthStencilFormat = D3DFMT_D24X8
+	            EndIf
+	        Else
+	            pp.AutoDepthStencilFormat = D3DFMT_D32
+	        EndIf
+	    EndIf
+	EndIf
 	
 	Local cflags=D3DCREATE_FPU_PRESERVE
-	
+
 	'OK, try hardware vertex processing...
 	Local tflags=D3DCREATE_PUREDEVICE|D3DCREATE_HARDWARE_VERTEXPROCESSING|cflags
 	If _d3d.CreateDevice( 0,D3DDEVTYPE_HAL,hwnd,tflags,pp,_d3dDev )<0
@@ -80,11 +121,11 @@ Function OpenD3DDevice( hwnd,width,height,depth,hertz,flags )
 		'Failed! Try mixed vertex processing...
 		tflags=D3DCREATE_MIXED_VERTEXPROCESSING|cflags
 		If _d3d.CreateDevice( 0,D3DDEVTYPE_HAL,hwnd,tflags,pp,_d3dDev )<0
-	
-			'Failed! Try software vertex processing...	
+
+			'Failed! Try software vertex processing...
 			tflags=D3DCREATE_SOFTWARE_VERTEXPROCESSING|cflags
 			If _d3d.CreateDevice( 0,D3DDEVTYPE_HAL,hwnd,tflags,pp,_d3dDev )<0
-			
+
 				'Failed! Go home and watch family guy instead...
 				Return False
 			EndIf
@@ -94,9 +135,9 @@ Function OpenD3DDevice( hwnd,width,height,depth,hertz,flags )
 	_presentParams=pp
 
 	_d3dDevRefs:+1
-	
+
 	_autoRelease=New TList
-	
+
 	Return True
 End Function
 
@@ -119,7 +160,7 @@ Function ResetD3DDevice()
 	If _d3dDev.Reset( _presentParams )<0
 		Throw "_d3dDev.Reset failed"
 	EndIf
-		
+
 End Function
 
 Public
@@ -133,7 +174,7 @@ Type TD3D9Graphics Extends TGraphics
 		Local height=rect[3]-rect[1]
 
 		OpenD3DDevice hwnd,width,height,0,0,flags
-		
+
 		_hwnd=hwnd
 		_width=width
 		_height=height
@@ -141,7 +182,7 @@ Type TD3D9Graphics Extends TGraphics
 		_attached=True
 		Return Self
 	End Method
-	
+
 	Method Create:TD3D9Graphics( width,height,depth,hertz,flags )
 		Local wstyle
 
@@ -150,18 +191,18 @@ Type TD3D9Graphics Extends TGraphics
 		Else
 			wstyle=WS_VISIBLE|WS_CAPTION|WS_SYSMENU|WS_MINIMIZEBOX
 		EndIf
-		
+
 		Local rect[4]
 
 		If Not depth
 			Local desktopRect[4]
 			GetWindowRect GetDesktopWindow(),desktopRect
-				
-			rect[0]=desktopRect[2]/2-width/2;		
-			rect[1]=desktopRect[3]/2-height/2;		
+
+			rect[0]=desktopRect[2]/2-width/2;
+			rect[1]=desktopRect[3]/2-height/2;
 			rect[2]=rect[0]+width;
 			rect[3]=rect[1]+height;
-				
+
 			AdjustWindowRect rect,wstyle,0
 		EndIf
 
@@ -173,22 +214,22 @@ Type TD3D9Graphics Extends TGraphics
 			width=rect[2]-rect[0]
 			height=rect[3]-rect[1]
 		EndIf
-		
+
 		If Not OpenD3DDevice( hwnd,width,height,depth,hertz,flags )
 			DestroyWindow hwnd
 			Return Null
 		EndIf
-		
+
 		_hwnd=hwnd
 		_width=width
 		_height=height
 		_depth=depth
 		_hertz=hertz
 		_flags=flags
-		
+
 		Return Self
 	End Method
-	
+
 	Method GetDirect3DDevice:IDirect3DDevice9()
 		Return _d3dDev
 	End Method
@@ -206,10 +247,10 @@ Type TD3D9Graphics Extends TGraphics
 			EndIf
 		EndIf
 	End Method
-	
+
 	'NOTE: Returns 1 if flip was successful, otherwise device lost or reset...
 	Method Flip( sync )
-	
+
 		Local reset
 
 		If sync sync=D3DPRESENT_INTERVAL_ONE Else sync=D3DPRESENT_INTERVAL_IMMEDIATE
@@ -217,7 +258,7 @@ Type TD3D9Graphics Extends TGraphics
 			_presentParams.PresentationInterval=sync
 			reset=True
 		EndIf
-		
+
 		Select _d3dDev.TestCooperativeLevel()
 		Case D3D_OK
 			If reset
@@ -225,7 +266,7 @@ Type TD3D9Graphics Extends TGraphics
 				ResetD3DDevice
 
 			Else If _attached
-			
+
 				Local rect[]=[0,0,_width,_height]
 				Return _d3dDev.Present( rect,rect,_hwnd,Null )>=0
 
@@ -239,14 +280,14 @@ Type TD3D9Graphics Extends TGraphics
 			ResetD3DDevice
 
 		End Select
-		
-		
+
+
 	End Method
 
 	Method Driver:TGraphicsDriver()
 		Return _driver
 	End Method
-	
+
 	Method GetSettings( width Var,height Var,depth Var,hertz Var,flags Var )
 		'
 		ValidateSize
@@ -270,7 +311,7 @@ Type TD3D9Graphics Extends TGraphics
 		t.unk=unk
 		_autoRelease.AddLast t
 	End Method
-	
+
 	Method ReleaseNow( unk:IUnknown )
 		For Local t:TD3D9AutoRelease=EachIn _autoRelease
 			If t.unk=unk
@@ -281,7 +322,7 @@ Type TD3D9Graphics Extends TGraphics
 		Next
 	End Method
 
-	
+
 	Field _hwnd
 	Field _width
 	Field _height
@@ -295,13 +336,13 @@ End Type
 Type TD3D9GraphicsDriver Extends TGraphicsDriver
 
 	Method Create:TD3D9GraphicsDriver()
-	
+
 		'create d3d9
 		If Not d3d9Lib Return
-		
+
 		_d3d=Direct3DCreate9( 32 )
 		If Not _d3d Return Null
-		
+
 		'get caps
 		_d3dCaps=New D3DCAPS9
 		If _d3d.GetDeviceCaps( D3DADAPTER_DEFAULT,D3DDEVTYPE_HAL,_d3dCaps )<0
@@ -310,7 +351,7 @@ Type TD3D9GraphicsDriver Extends TGraphicsDriver
 			Return Null
 		EndIf
 
-		'enum graphics modes		
+		'enum graphics modes
 		Local n=_d3d.GetAdapterModeCount( D3DADAPTER_DEFAULT,D3DFMT_X8R8G8B8 )
 		_modes=New TGraphicsMode[n]
 		Local j
@@ -320,18 +361,18 @@ Type TD3D9GraphicsDriver Extends TGraphicsDriver
 			If _d3d.EnumAdapterModes( D3DADAPTER_DEFAULT,D3DFMT_X8R8G8B8,i,d3dmode )<0
 				Continue
 			EndIf
-			
+
 			Local mode:TGraphicsMode=New TGraphicsMode
 			mode.width=d3dmode.Width
 			mode.height=d3dmode.Height
 			mode.hertz=d3dmode.RefreshRate
 			mode.depth=32
-			
+
 			_modes[j]=mode
 			j:+1
 		Next
 		_modes=_modes[..j]
-	
+
 		'register wndclass
 		Local wndclass:WNDCLASSW=New WNDCLASSW
 		wndclass.hInstance=GetModuleHandleW( Null )
@@ -343,31 +384,31 @@ Type TD3D9GraphicsDriver Extends TGraphicsDriver
 
 		Return Self
 	End Method
-	
+
 	Method GraphicsModes:TGraphicsMode[]()
 		Return _modes
 	End Method
-	
+
 	Method AttachGraphics:TD3D9Graphics( widget,flags )
 		Return New TD3D9Graphics.Attach( widget,flags )
 	End Method
-	
+
 	Method CreateGraphics:TD3D9Graphics( width,height,depth,hertz,flags )
 		Return New TD3D9Graphics.Create( width,height,depth,hertz,flags )
 	End Method
-	
+
 	Method SetGraphics( g:TGraphics )
 		_graphics=TD3D9Graphics( g )
 	End Method
-	
+
 	Method Flip( sync )
 		Return _graphics.Flip( sync )
 	End Method
-	
+
 	Method GetDirect3D:IDirect3D9()
 		Return _d3d
 	End Method
-	
+
 End Type
 
 Function D3D9GraphicsDriver:TD3D9GraphicsDriver()


### PR DESCRIPTION
Hi,

A few years ago, I wrote a [tweak](https://github.com/kfprimm/maxb3d/wiki/BRL.DXGraphics-Tweak) for `brl.dxgraphics` so that the [MaxB3D](https://github.com/kfprimm/maxb3d) D3D9 driver would have access to the depth buffer. This tweak has been tested over the past few years with MaxB3D projects.

Beyond the several additions in `OpenD3DDevice`, the other edits are where my editor automatically removed the extra whitespace.

Thanks!
