### PR TITLE
[brl.openalaudio] Make TOpenALSource publically accessible.

### DIFF
--- a/mod/brl.mod/openalaudio.mod/openalaudio.bmx
+++ b/mod/brl.mod/openalaudio.mod/openalaudio.bmx
@@ -58,6 +58,24 @@ Function CheckAL()
 	Return False
 End Function
 
+Function EnumOpenALDevices$[]()
+	Local p:Byte Ptr=alcGetString( 0,ALC_DEVICE_SPECIFIER )
+	If Not p Return
+	Local devs$[100],n
+	While p[0] And n<100
+		Local sz
+		Repeat
+			sz:+1
+		Until Not p[sz]
+		devs[n]=String.FromBytes( p,sz )
+		n:+1
+		p:+sz+1
+	Wend
+	Return devs[..n]
+End Function
+
+Public
+
 Type TOpenALSource
 
 	Field _succ:TOpenALSource,_id,_seq,_sound:TOpenALSound,_avail
@@ -93,24 +111,6 @@ Type TOpenALSource
 	End Method
 	
 End Type
-
-Function EnumOpenALDevices$[]()
-	Local p:Byte Ptr=alcGetString( 0,ALC_DEVICE_SPECIFIER )
-	If Not p Return
-	Local devs$[100],n
-	While p[0] And n<100
-		Local sz
-		Repeat
-			sz:+1
-		Until Not p[sz]
-		devs[n]=String.FromBytes( p,sz )
-		n:+1
-		p:+sz+1
-	Wend
-	Return devs[..n]
-End Function
-
-Public
 
 Type TOpenALSound Extends TSound
 


### PR DESCRIPTION
This is a simple, straight-forward change.

As it stands, you can access the underlying `TOpenALSource` from `TOpenALChannel._source`, but because `TOpenALSource` is private you get a compilation error.

I wanted to reuse the existing sound infrastructure in MaxB3D so this required me to resort to a [very ugly reflection hack](https://github.com/kfprimm/maxb3d/blob/master/openalaudio3d.mod/openalaudio3d.bmx#L43) so that I could get the OpenAL handle.

Despite the way the diff is presented (yay git), the only change was moving `TOpenALSource` past the `Public` declaration.

I don't think any specific test code is required to prove this since no logic was changed. Running any audio sample after applying this patch will do.

Thanks!
