### PR TITLE
Added executables, backups, and modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,18 @@
 !mod/brl.mod/blitz.mod/blitz_ex.*.s
 !mod/brl.mod/blitz.mod/blitz_ftoi.*.s
 !mod/brl.mod/blitz.mod/blitz_gc.*.s
+
+# win32, mac, linux debug executables
+*.debug.exe
+*.debug.app
+*.debug
+
+# MaxIDE binary and it's backup files
+/MaxIDE*
+*.bak
+
+# all but standard mods
+/mod/*.mod/
+!/mod/brl.mod/
+!/mod/pub.mod/
+!/mod/maxgui.mod/


### PR DESCRIPTION
I've added some standard ignores to `.gitignore`. With the numerous mod scopes I have installed, each under their own git repo, it helps me to avoid committing something I shouldn't.
