### PR TITLE
Fixed freeaudios coreaudio device removing use of deprecated interface

### DIFF
--- a/mod/pub.mod/freeaudio.mod/coreaudiodevice.cpp
+++ b/mod/pub.mod/freeaudio.mod/coreaudiodevice.cpp
@@ -4,9 +4,6 @@
 
 #ifdef __APPLE__
 
-#include <CoreServices/CoreServices.h>
-#include <AudioUnit/AudioUnit.h>
-#include <CoreAudio/CoreAudio.h>
 #include <AudioToolbox/AudioToolbox.h>
 
 extern "C" audiodevice *OpenCoreAudioDevice();
@@ -57,11 +54,11 @@ struct coreaudio:audiodevice{
 	}
 
 	int initoutput(){
-		ComponentDescription	desc;  
-		Component				comp;
-		OSStatus				err;
-		UInt32					size;
-		Boolean 				canwrite;
+		AudioComponentDescription desc;  
+		AudioComponent comp;
+		OSStatus err;
+		UInt32 size;
+		Boolean canwrite;
 		
 		AudioStreamBasicDescription 	inputdesc,outputdesc;
 
@@ -71,8 +68,12 @@ struct coreaudio:audiodevice{
 		desc.componentFlags=0;
 		desc.componentFlagsMask=0;
 
-		comp=FindNextComponent(NULL,&desc);if (comp==NULL) return -1;
-		err=OpenAComponent(comp,&out);if (err) return err;				
+		comp=AudioComponentFindNext(NULL,&desc);
+		if (comp==NULL) return -1;
+
+		err= AudioComponentInstanceNew(comp,&out);
+		if (err) return err;				
+
 		err=AudioUnitInitialize(out);if (err) return err;
 		
 		err=AudioUnitGetPropertyInfo(out,kAudioUnitProperty_StreamFormat,kAudioUnitScope_Output,0,&size,&canwrite);
@@ -104,7 +105,7 @@ struct coreaudio:audiodevice{
 //			printf("AudioConvertNew failed %.*s\n",4,(char*)&err);
 			return err;
 		}
-	
+
 		return err;
 	}
 

--- a/mod/pub.mod/freeaudio.mod/freeaudio.bmx
+++ b/mod/pub.mod/freeaudio.mod/freeaudio.bmx
@@ -1,12 +1,14 @@
 
 Module Pub.FreeAudio
 
-ModuleInfo "Version: 1.22"
+ModuleInfo "Version: 1.23"
 ModuleInfo "Author: Simon Armstrong"
 ModuleInfo "License: zlib/libpng"
 ModuleInfo "Copyright: Blitz Research Ltd"
 ModuleInfo "Modserver: BRL"
 
+ModuleInfo "History: 1.23 Release"
+ModuleInfo "History: Updated OS X coreaudio to not use deprecated API"
 ModuleInfo "History: 1.22 Release"
 ModuleInfo "History: Fixed leak with sound recycling"
 ModuleInfo "History: 1.21 Release"
@@ -55,6 +57,7 @@ Function OpenMultiMediaDevice()
 Function OpenDirectSoundDevice()
 End Extern
 ?MacOS
+Import "-framework CoreAudio"
 Import "-framework AudioUnit"
 Import "-framework AudioToolbox"
 Import "coreaudiodevice.cpp"


### PR DESCRIPTION
This patch fixes the warning you get on OS X 10.11 when running the CreateAudioSample example code.
