### PR TITLE
Added condition in blitz_memory.c

### DIFF
--- a/mod/brl.mod/blitz.mod/blitz_memory.c
+++ b/mod/brl.mod/blitz.mod/blitz_memory.c
@@ -35,8 +35,10 @@ void bbMemFree( void *p ){
 void *bbMemExtend( void *mem,int size,int new_size ){
 	void *p;
 	p=bbMemAlloc( new_size );
-	bbMemCopy( p,mem,size );
-	bbMemFree( mem );
+	if(mem != NULL){
+		bbMemCopy( p,mem,size );
+		bbMemFree( mem );
+	}
 	return p;
 }
 


### PR DESCRIPTION
bbMemExtend had unspecified behaviour if the old memory pointer was NULL,
now it will just MemAlloc when called with a NULL pointer.
This apparently fixes blitz-research/blitzmax#8